### PR TITLE
Set the Activity.Current to the current one

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -58,6 +58,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
             {
                 if (_diagnosticListener.IsEnabled(ActivityStopEventName, @event))
                 {
+                    Activity.Current ??= activity;
                     _diagnosticListener.StopActivity(activity, @event);
                 }
                 else
@@ -73,6 +74,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
             {
                 if (_diagnosticListener.IsEnabled(ActivityExceptionEventName, @event))
                 {
+                    Activity.Current ??= activity;
                     _diagnosticListener.Write(ActivityExceptionEventName, @event);
                 }
                 activity.Stop();


### PR DESCRIPTION
When Mongo driver asynchronous function is called the driver breaks the async flow by switching to another thread. As a result the Activity.Current is null in the new thread even while the activity is still in progress. The proposed change is in that case to set the Current.Activity to the current activity in that thread too to continue as expected. This scenario is described in more details here: https://github.com/dotnet/runtime/issues/25936.