### PR TITLE
Parallel activities failing test and fix

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -58,7 +58,10 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
             {
                 if (_diagnosticListener.IsEnabled(ActivityStopEventName, @event))
                 {
+                    var temp = Activity.Current;
+                    Activity.Current = activity;
                     _diagnosticListener.StopActivity(activity, @event);
+                    Activity.Current = temp;
                 }
                 else
                 {
@@ -73,7 +76,10 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
             {
                 if (_diagnosticListener.IsEnabled(ActivityExceptionEventName, @event))
                 {
+                    var temp = Activity.Current;
+                    Activity.Current = activity;
                     _diagnosticListener.Write(ActivityExceptionEventName, @event);
+                    Activity.Current = temp;
                 }
                 activity.Stop();
             }

--- a/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
+++ b/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -214,7 +215,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
 
             outerActivity.Stop();
 
-            activities.Count.ShouldBe(4);
+            activities.Count(activity => activity != null && activity.OperationName == DiagnosticsActivityEventSubscriber.ActivityName).ShouldBe(4);
 
             Activity.Current.ShouldBeNull();
         }


### PR DESCRIPTION
In order to reproduce an issue with the parallel activities I added the stricter assertion to the unit test to verify that not only there are the total of 4 activities added to the collection, but all of them are actually command related activities. As the result the test failed due to the fact that when the first activity stopped the Activity.Current became the outer activity and while handling the command succeeded event that wrong activity was collected. This is how the OpenTelemetry pulls the activity in their integration with the diagnostics and that's why the correct Activity.Current is important (https://github.com/open-telemetry/opentelemetry-dotnet/blob/7863cee67a7efc62bb57cd20ceb7351d8757f884/src/OpenTelemetry/Instrumentation/DiagnosticSourceListener.cs#L61).

In order to fix the failing test I added a couple of lines to save the current activity into a temp, setting it to being stopped activity and after stopping it returning to the previous activity.