### PR TITLE
Replacing Activity.Current to handle a case of async Mongo commands

### DIFF
--- a/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
+++ b/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
-using System.Threading.Tasks;
+using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Connections;
@@ -214,7 +214,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
 
             outerActivity.Stop();
 
-            activities.Count.ShouldBe(4);
+            activities.Count(activity => activity != null && activity.OperationName == DiagnosticsActivityEventSubscriber.ActivityName).ShouldBe(4);
 
             Activity.Current.ShouldBeNull();
         }


### PR DESCRIPTION
Due to the async MongoDb commands not sticking to the same async flow the Activity.Current could be changed when the CommandSucceededEvent or CommandFailedEvent are handled. In order for the span to end correctly the change is replacing the Activity.Current, ends the span and then restores the Activity.Current to the previous state.