### PR TITLE
Add filter function to instrumentation options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityE
 var mongoClient = new MongoClient(clientSettings);
 ```
 
+To filter activities by collection name:
+
+```csharp
+var clientSettings = MongoClientSettings.FromUrl(mongoUrl);
+var options = new InstrumentationOptions { Filter = @event => !"collectionToIgnore".Equals(@event.GetCollectionName()) };
+clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber(options));
+var mongoClient = new MongoClient(clientSettings);
+```
+
 This package exposes an [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource?view=net-5.0) with a `Name` the same as the assembly, `MongoDB.Driver.Core.Extensions.DiagnosticSources`. Use this name in any [`ActivityListener`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitylistener?view=net-5.0)-based listeners.
 
 All the available [OpenTelemetry semantic tags](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md) are set.

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/CommandStartedEventExtensions.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/CommandStartedEventExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using MongoDB.Driver.Core.Events;
+
+namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
+{
+    public static class CommandStartedEventExtensions
+    {
+        private static readonly HashSet<string> CommandsWithCollectionNameAsValue =
+            new HashSet<string>
+            {
+                "aggregate",
+                "count",
+                "distinct",
+                "mapReduce",
+                "geoSearch",
+                "delete",
+                "find",
+                "killCursors",
+                "findAndModify",
+                "insert",
+                "update",
+                "create",
+                "drop",
+                "createIndexes",
+                "listIndexes"
+            };
+
+        public static string GetCollectionName(this CommandStartedEvent @event)
+        {
+            if (@event.CommandName == "getMore")
+            {
+                if (@event.Command.Contains("collection"))
+                {
+                    var collectionValue = @event.Command.GetValue("collection");
+                    if (collectionValue.IsString)
+                    {
+                        return collectionValue.AsString;
+                    }
+                }
+            }
+            else if (CommandsWithCollectionNameAsValue.Contains(@event.CommandName))
+            {
+                var commandValue = @event.Command.GetValue(@event.CommandName);
+                if (commandValue != null && commandValue.IsString)
+                {
+                    return commandValue.AsString;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/InstrumentationOptions.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/InstrumentationOptions.cs
@@ -1,7 +1,11 @@
-﻿namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
+﻿using System;
+using MongoDB.Driver.Core.Events;
+
+namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
 {
     public class InstrumentationOptions
     {
         public bool CaptureCommandText { get; set; }
+        public Func<CommandStartedEvent, bool> Filter { get; set; }
     }
 }


### PR DESCRIPTION
When filter is null or returns true activity is created, when filter returns false activity is not created.
Resolves #8
```
builder.Subscribe(new DiagnosticsActivityEventSubscriber(new InstrumentationOptions
	{
		Filter = e => new[] { "getLastError", "isMaster", "buildinfo" }.All(x => !x.Equals(e.CommandName))
	}));
```