### PR TITLE
Send activity start and stop events to DiagnosticSource

### DIFF
--- a/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/MongoDBDiagnosticObserver.cs
+++ b/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/MongoDBDiagnosticObserver.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
+{
+    internal class MongoDBDiagnosticObserver : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object>>
+    {
+        private readonly List<IDisposable> _subscriptions = new List<IDisposable>();
+        private readonly Action<KeyValuePair<string, object>> nextEventCallback;
+
+        public MongoDBDiagnosticObserver(Action<KeyValuePair<string, object>> nextEventCallback)
+        {
+            this.nextEventCallback = nextEventCallback;
+        }
+
+        void IObserver<KeyValuePair<string, object>>.OnNext(KeyValuePair<string, object> pair)
+        {
+            this.nextEventCallback(pair);
+        }
+
+        void IObserver<KeyValuePair<string, object>>.OnError(Exception error)
+        { }
+
+        void IObserver<KeyValuePair<string, object>>.OnCompleted()
+        { }
+
+        void IObserver<DiagnosticListener>.OnNext(DiagnosticListener diagnosticListener)
+        {
+            if (diagnosticListener.Name == "MongoDB.Driver.Core.Extensions.DiagnosticSources")
+            {
+                var subscription = diagnosticListener.Subscribe(this);
+                _subscriptions.Add(subscription);
+            }
+        }
+
+        void IObserver<DiagnosticListener>.OnError(Exception error)
+        { }
+
+        void IObserver<DiagnosticListener>.OnCompleted()
+        {
+            _subscriptions.ForEach(x => x.Dispose());
+            _subscriptions.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Send activity start and stop events to DiagnosticSource to support older DiagnosticSource based instrumentations.

Resolves #11 