### PR TITLE
Added option to dynamically enable command text based on other command properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityE
 var mongoClient = new MongoClient(clientSettings);
 ```
 
+To capture the command text based on a predicate:
+
+```csharp
+var clientSettings = MongoClientSettings.FromUrl(mongoUrl);
+var options = new InstrumentationOptions { ShouldCaptureCommandText = @event => @event.CommandName == "find" };
+clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber(options));
+var mongoClient = new MongoClient(clientSettings);
+```
+
 To filter activities by collection name:
 
 ```csharp

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -72,7 +72,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
                     break;
             }
 
-            if (activity.IsAllDataRequested && (_options.CaptureCommandText || (_options.ShouldCaptureCommandText is not null && _options.ShouldCaptureCommandText.Invoke(@event))))
+            if (activity.IsAllDataRequested && (_options.CaptureCommandText || _options.ShouldCaptureCommandText?.Invoke(@event) == true))
             {
                 activity.AddTag("db.statement", @event.Command.ToString());
             }

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -72,7 +72,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
                     break;
             }
 
-            if (activity.IsAllDataRequested && _options.CaptureCommandText)
+            if (activity.IsAllDataRequested && (_options.CaptureCommandText || (_options.ShouldCaptureCommandText is not null && _options.ShouldCaptureCommandText.Invoke(@event))))
             {
                 activity.AddTag("db.statement", @event.Command.ToString());
             }

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/InstrumentationOptions.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/InstrumentationOptions.cs
@@ -6,6 +6,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
     public class InstrumentationOptions
     {
         public bool CaptureCommandText { get; set; }
+        public Func<CommandStartedEvent, bool> ShouldCaptureCommandText { get; set; }
         public Func<CommandStartedEvent, bool> ShouldStartActivity { get; set; }
     }
 }


### PR DESCRIPTION
I found myself having huge `insert` db statements (~3/4 million characters long) in our projects. Those traces were eating up all the storage in our servers and it slowed down tools like Grafana or Jaeger.

I would like to still have the trace data, but to not generate the `db.statement` tag in these cases. For other operations, their size is relatively small and therefore I want to include the `db.statement` tag.

The new `InstrumentationOptions.ShouldCaptureCommandText` option allows for this and it can be overridden by the `InstrumentationOptions.CaptureCommandText` to maintain compatibility.