### PR TITLE
Update attributes to be compliant with OpenTelemetry

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -57,18 +57,18 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
             activity.AddTag("db.name", @event.DatabaseNamespace?.DatabaseName);
             activity.AddTag("db.mongodb.collection", collectionName);
             activity.AddTag("db.operation", @event.CommandName);
-            activity.AddTag("net.transport", "ip_tcp");
+            activity.AddTag("network.transport", "tcp");
 
             var endPoint = @event.ConnectionId?.ServerId?.EndPoint;
             switch (endPoint)
             {
                 case IPEndPoint ipEndPoint:
-                    activity.AddTag("net.peer.port", ipEndPoint.Port.ToString());
-                    activity.AddTag("net.sock.peer.addr", ipEndPoint.Address.ToString());
+                    activity.AddTag("network.peer.address", ipEndPoint.Address.ToString());
+                    activity.AddTag("network.peer.port", ipEndPoint.Port.ToString());
                     break;
                 case DnsEndPoint dnsEndPoint:
-                    activity.AddTag("net.peer.name", dnsEndPoint.Host);
-                    activity.AddTag("net.peer.port", dnsEndPoint.Port.ToString());
+                    activity.AddTag("server.address", dnsEndPoint.Host);
+                    activity.AddTag("server.port", dnsEndPoint.Port.ToString());
                     break;
             }
 
@@ -107,7 +107,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
                         activity.AddTag("exception.message", @event.Failure.Message);
                         activity.AddTag("exception.stacktrace", @event.Failure.StackTrace);
                     }
-   
+
                     activity.SetStatus(ActivityStatusCode.Error);
                     activity.Stop();
                 });

--- a/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
+++ b/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
@@ -191,8 +191,8 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
                     activity.Tags.SingleOrDefault(t => t.Key == "db.mongodb.collection").Value.ShouldBe("my_collection");
                     activity.Tags.SingleOrDefault(t => t.Key == "db.operation").Value.ShouldBe("update");
                     activity.Tags.SingleOrDefault(t => t.Key == "db.statement").ShouldBe(default);
-                    activity.Tags.SingleOrDefault(t => t.Key == "net.peer.name").Value.ShouldBe("localhost");
-                    activity.Tags.SingleOrDefault(t => t.Key == "net.peer.port").Value.ShouldBe("8000");
+                    activity.Tags.SingleOrDefault(t => t.Key == "server.address").Value.ShouldBe("localhost");
+                    activity.Tags.SingleOrDefault(t => t.Key == "server.port").Value.ShouldBe("8000");
                     activity.Tags.SingleOrDefault(t => t.Key == "otel.status_code").Value.ShouldBe("OK");
 
                     stopFired = true;


### PR DESCRIPTION
Update few attributes to match the spec (https://opentelemetry.io/docs/specs/semconv/database/database-spans/ and https://opentelemetry.io/docs/specs/semconv/database/mongodb/):
- Rename `net.transport` to `network.transport`
- Update value of `network.transport` from `ip_tcp` to `tcp`
- Rename `net.sock.peer.addr` to `network.peer.address` (in case `EndPoint` is `IPEndPoint`)
- Rename `net.peer.port` to `network.peer.port` (in case `EndPoint` is `IPEndPoint`)
- Rename `net.peer.name` to `server.address` (in case `EndPoint` is `DnsEndPoint`)
- Rename `net.peer.port` to `server.port` (in case `EndPoint` is `DnsEndPoint`)