### PR TITLE
Set ActivitySource.Version to NuGet package version

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -12,8 +12,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
         private readonly InstrumentationOptions _options;
         internal static readonly AssemblyName AssemblyName = typeof(DiagnosticsActivityEventSubscriber).Assembly.GetName();
         internal static readonly string ActivitySourceName = AssemblyName.Name;
-        internal static readonly Version Version = AssemblyName.Version;
-        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
+        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, SignalVersionHelper.GetVersion<DiagnosticsActivityEventSubscriber>());
 
         public const string ActivityName = "MongoDB.Driver.Core.Events.Command";
 

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/SignalVersionHelper.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/SignalVersionHelper.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+
+namespace MongoDB.Driver.Core.Extensions.DiagnosticSources;
+
+internal static class SignalVersionHelper
+{
+    public static string GetVersion<T>()
+    {
+        return typeof(T).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0];
+    }
+}


### PR DESCRIPTION
Fixes: issue when it is hard to determine what is the instrumentation library version used in end-user project.
Previously this package was always reporting 1.0.0.0 (Assembly version).
MinVer is setting more user friendly value in `AssemblyInformationalVersionAttribute` attribute in following format: `1.7.2-alpha.0.39+69cc79aed00a37c103b9e46488e2001db959a1ab`.

Similar changes in otel-contrib repository: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624

Results after changes:
<img width="905" alt="image" src="https://github.com/jbogard/MongoDB.Driver.Core.Extensions.DiagnosticSources/assets/5972917/31152366-0376-423f-887c-b8d376cede49">

