### PR TITLE
Replace otel.status_code and otel.status_description by Activity.Status

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -86,8 +86,6 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
             {
                 WithReplacedActivityCurrent(activity, () =>
                 {
-                    activity.AddTag("otel.status_code", "OK");
-                    activity.SetStatus(ActivityStatusCode.Ok);
                     activity.Stop();
                 });
             }
@@ -101,8 +99,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
                 {
                     if (activity.IsAllDataRequested)
                     {
-                        activity.AddTag("otel.status_code", "ERROR");
-                        activity.AddTag("otel.status_description", @event.Failure.Message);
+                        activity.SetStatus(ActivityStatusCode.Error, @event.Failure.Message);
                         activity.AddTag("exception.type", @event.Failure.GetType().FullName);
                         activity.AddTag("exception.message", @event.Failure.Message);
                         activity.AddTag("exception.stacktrace", @event.Failure.StackTrace);


### PR DESCRIPTION
There is a recommendation to avoid setting Status.Ok. It should stay as Unset

Ref: https://github.com/open-telemetry/opentelemetry-dotnet/issues/2569