### PR TITLE
Resolves issue with unexpected InvalidOperationExceptions

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -113,6 +113,12 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
         private static void WithReplacedActivityCurrent(Activity activity, Action action)
         {
             var current = Activity.Current;
+            if (activity == current)
+            {
+                action();
+                return;
+            }
+
             try
             {
                 Activity.Current = activity;
@@ -120,7 +126,14 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
             }
             finally
             {
-                Activity.Current = current;
+                if (current?.IsStopped == true) // it's forbidden to assign stopped activity to Activity.Current
+                {
+                    Activity.Current = null;
+                }
+                else
+                {
+                    Activity.Current = current;
+                }
             }
         }
     }


### PR DESCRIPTION
Hello.

This PR resolves issue #30.

The problem is that `DiagnosticsActivityEventSubscriber` wants to return previously captured current activity to `Activity.Current` property again. In the `Activity.Current` setter there is a check that fails when the activity is stopped. When the "parent" activity is stopped in the meanwhile, exception is thrown.

The same code raises the exception also when you call a sync version of a mongo command. In this case, command's activity is the same as the `Activity.Current` activity. Inside `action()`, activity gets stopped, and afterwards activity is again assigned to `Activity.Current` property.

Both issues should be fixed by this PR.

Thanks.