### PR TITLE
chore!: update minimal required version of MongoDB.Driver to v2.28.0 …

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/MongoDB.Driver.Core.Extensions.DiagnosticSources.csproj
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/MongoDB.Driver.Core.Extensions.DiagnosticSources.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver.Core" Version="[2.13.3,3.0)" />
+        <PackageReference Include="MongoDB.Driver.Core" Version="[2.28.0,3.0)" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
         <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />

--- a/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
+++ b/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
@@ -153,7 +153,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
                 {"update", "my_collection"}
             });
             startEvent(new CommandStartedEvent("update", command, databaseNamespace, null, 1, connectionId));
-            stopEvent(new CommandFailedEvent("update", new Exception("Failed"), null, 1, connectionId, TimeSpan.Zero));
+            stopEvent(new CommandFailedEvent("update", databaseNamespace, new Exception("Failed"), null, 1, connectionId, TimeSpan.Zero));
 
             startFired.ShouldBeTrue();
             exceptionFired.ShouldBeTrue();
@@ -210,7 +210,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
                 {"update", "my_collection"}
             });
             startEvent(new CommandStartedEvent("update", command, databaseNamespace, null, 1, connectionId));
-            stopEvent(new CommandSucceededEvent("update", command, null, 1, connectionId, TimeSpan.Zero));
+            stopEvent(new CommandSucceededEvent("update", command, databaseNamespace, null, 1, connectionId, TimeSpan.Zero));
 
             startFired.ShouldBeTrue();
             stopFired.ShouldBeTrue();
@@ -258,7 +258,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
             var connectionId = new ConnectionId(new ServerId(new ClusterId(), new DnsEndPoint("localhost", 8000)));
             var databaseNamespace = new DatabaseNamespace("test");
             startEvent(new CommandStartedEvent("update", command, databaseNamespace, null, 1, connectionId));
-            stopEvent(new CommandSucceededEvent("update", command, null, 1, connectionId, TimeSpan.Zero));
+            stopEvent(new CommandSucceededEvent("update", command, databaseNamespace, null, 1, connectionId, TimeSpan.Zero));
 
             startFired.ShouldBeTrue();
             stopFired.ShouldBeTrue();
@@ -298,8 +298,8 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
             });
             startEvent(new CommandStartedEvent("update", updateCommand, databaseNamespace, null, 1, connectionId));
             startEvent(new CommandStartedEvent("insert", insertCommand, databaseNamespace, null, 2, connectionId));
-            stopEvent(new CommandSucceededEvent("update", updateCommand, null, 1, connectionId, TimeSpan.Zero));
-            stopEvent(new CommandSucceededEvent("insert", insertCommand, null, 2, connectionId, TimeSpan.Zero));
+            stopEvent(new CommandSucceededEvent("update", updateCommand, databaseNamespace, null, 1, connectionId, TimeSpan.Zero));
+            stopEvent(new CommandSucceededEvent("insert", insertCommand, databaseNamespace, null, 2, connectionId, TimeSpan.Zero));
 
             outerActivity.Stop();
 


### PR DESCRIPTION
…following their strong naming of their assemblies

Addresses #34 

See:

https://github.com/mongodb/mongo-csharp-driver/releases/tag/v2.28.0

and

https://www.mongodb.com/community/forums/t/net-c-driver-strong-naming/291649

