### PR TITLE
Update attributes to comply with OTel spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./Push.ps1
         shell: pwsh
       - name: Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts/**/*

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var mongoClient = new MongoClient(clientSettings);
 
 This package exposes an [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource?view=net-5.0) with a `Name` the same as the assembly, `MongoDB.Driver.Core.Extensions.DiagnosticSources`. Use this name in any [`ActivityListener`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitylistener?view=net-5.0)-based listeners.
 
-All the available [OpenTelemetry semantic tags](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md) are set.
+All the available [OpenTelemetry semantic tags](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md) are set.
  
 This package supports MongoDB C# Driver versions 2.28.0 to 3.0.
 

--- a/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
+++ b/tests/MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests/DiagnosticsActivityEventSubscriberTests.cs
@@ -179,15 +179,15 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
                 {
                     activity.ShouldNotBeNull();
                     activity.OperationName.ShouldBe(DiagnosticsActivityEventSubscriber.ActivityName);
-                    var instanceTag = activity.Tags.SingleOrDefault(t => t.Key == "db.name");
+                    var instanceTag = activity.Tags.SingleOrDefault(t => t.Key == "db.namespace");
                     instanceTag.ShouldNotBe(default);
                     instanceTag.Value.ShouldBe("test");
 
                     activity.Tags.SingleOrDefault(t => t.Key == "db.system").Value.ShouldBe("mongodb");
                     activity.Tags.SingleOrDefault(t => t.Key == "db.connection_id").Value.ShouldBe("{ ServerId : { ClusterId : 42, EndPoint : \"Unspecified/localhost:8000\" }, LocalValue : 43 }");
-                    activity.Tags.SingleOrDefault(t => t.Key == "db.mongodb.collection").Value.ShouldBe("my_collection");
-                    activity.Tags.SingleOrDefault(t => t.Key == "db.operation").Value.ShouldBe("update");
-                    activity.Tags.SingleOrDefault(t => t.Key == "db.statement").ShouldBe(default);
+                    activity.Tags.SingleOrDefault(t => t.Key == "db.collection.name").Value.ShouldBe("my_collection");
+                    activity.Tags.SingleOrDefault(t => t.Key == "db.operation.name").Value.ShouldBe("update");
+                    activity.Tags.SingleOrDefault(t => t.Key == "db.query.text").ShouldBe(default);
                     activity.Tags.SingleOrDefault(t => t.Key == "server.address").Value.ShouldBe("localhost");
                     activity.Tags.SingleOrDefault(t => t.Key == "server.port").Value.ShouldBe("8000");
                     activity.Status.ShouldBe(ActivityStatusCode.Unset);
@@ -240,7 +240,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources.Tests
                 {
                     activity.ShouldNotBeNull();
                     activity.OperationName.ShouldBe(DiagnosticsActivityEventSubscriber.ActivityName);
-                    var statementTag = activity.Tags.SingleOrDefault(t => t.Key == "db.statement");
+                    var statementTag = activity.Tags.SingleOrDefault(t => t.Key == "db.query.text");
                     statementTag.ShouldNotBe(default);
                     statementTag.Value.ShouldBe(command.ToString());
 


### PR DESCRIPTION
Update few attributes to match the spec (https://opentelemetry.io/docs/specs/semconv/database/database-spans/ and https://opentelemetry.io/docs/specs/semconv/database/mongodb/):
- Update activity display name
- Rename `db.name` to `db.namespace`
- Rename `db.mongodb.collection` to `db.collection.name`
- Rename `db.operation` to `db.operation.name`
- Rename `db.statement` to `db.query.text`
- Exception details should be reported as event instead of tags (https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/)