### PR TITLE
Use FrozenSet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./Push.ps1
         shell: pwsh
       - name: Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts/**/*

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/CommandStartedEventExtensions.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/CommandStartedEventExtensions.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Frozen;
 using MongoDB.Driver.Core.Events;
 
 namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
 {
     public static class CommandStartedEventExtensions
     {
-        private static readonly HashSet<string> CommandsWithCollectionNameAsValue =
+        private static readonly FrozenSet<string> CommandsWithCollectionNameAsValue =
             new HashSet<string>
             {
                 "aggregate",
@@ -23,7 +24,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
                 "drop",
                 "createIndexes",
                 "listIndexes"
-            };
+            }.ToFrozenSet();
 
         public static string GetCollectionName(this CommandStartedEvent @event)
         {

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/MongoDB.Driver.Core.Extensions.DiagnosticSources.csproj
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/MongoDB.Driver.Core.Extensions.DiagnosticSources.csproj
@@ -15,10 +15,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver.Core" Version="[2.28.0,3.0)" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
         <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
+        <PackageReference Include="MongoDB.Driver.Core" Version="[2.28.0,3.0)" />
+        <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Convert `CommandStartedEventExtensions.CommandsWithCollectionNameAsValue`, on which only read operation is performed, to `FrozenSet` in order to improve performance.