### PR TITLE
Upgrade project dependency to MongoDB C# Driver 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ This package exposes an [`ActivitySource`](https://docs.microsoft.com/en-us/dotn
 
 All the available [OpenTelemetry semantic tags](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md) are set.
  
-This package supports MongoDB C# Driver versions 2.28.0 to 3.0.
+This package supports MongoDB C# Driver versions 3.0.0 and above.
 

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/MongoDB.Driver.Core.Extensions.DiagnosticSources.csproj
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/MongoDB.Driver.Core.Extensions.DiagnosticSources.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>net6.0;netstandard2.1;net472</TargetFrameworks>
         <NoWarn>NU5100</NoWarn>
         <Authors>Jimmy Bogard</Authors>
         <Copyright>Jimmy Bogard</Copyright>
@@ -17,7 +17,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
         <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
-        <PackageReference Include="MongoDB.Driver.Core" Version="[2.28.0,3.0)" />
+        <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
         <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Upgrades the MongoDB dependency to 3.0.0.

Note that as per the driver this drops support for netstandard2.0 and replaces it with netstandard2.1, net6 and net472.

As this is a breaking change you might want to bump the major (2.0.0) or align with the C# Driver version (3.0.0).

I did notice that the tests only run for .NET 6 so don't cover the other targets. I can change this if preferable. 

Fixes #40