### PR TITLE
public ActivitySourceName

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityE
 var mongoClient = new MongoClient(clientSettings);
 ```
 
-This package exposes an [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource?view=net-5.0) with a `Name` the same as the assembly, `MongoDB.Driver.Core.Extensions.DiagnosticSources`. Use this name in any [`ActivityListener`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitylistener?view=net-5.0)-based listeners.
+This package exposes an [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource?view=net-5.0) with a `Name` the same as the assembly, `MongoDB.Driver.Core.Extensions.DiagnosticSources`, or use the `DiagnosticsActivityEventSubscriber.ActivitySourceName`. Use this name in any [`ActivityListener`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitylistener?view=net-5.0)-based listeners.
 
 All the available [OpenTelemetry semantic tags](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md) are set.
  

--- a/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
@@ -11,7 +11,7 @@ namespace MongoDB.Driver.Core.Extensions.DiagnosticSources
     {
         private readonly InstrumentationOptions _options;
         internal static readonly AssemblyName AssemblyName = typeof(DiagnosticsActivityEventSubscriber).Assembly.GetName();
-        internal static readonly string ActivitySourceName = AssemblyName.Name;
+        public static readonly string ActivitySourceName = AssemblyName.Name;
         internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, SignalVersionHelper.GetVersion<DiagnosticsActivityEventSubscriber>());
 
         public const string ActivityName = "MongoDB.Driver.Core.Events.Command";


### PR DESCRIPTION
public `ActivitySourceName` so that we could reference the ActivitySourceName directly

fixes #36 