### PR TITLE
clarify README about GridFS and CaptureCommandText

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityE
 var mongoClient = new MongoClient(clientSettings);
 ```
 
+When using `CaptureCommandText = true` with GridFS, consider customizing the `ShouldStartActivity` logic to prevent large binary file data from chunk collection operations being captured in activity traces.
+
 This package exposes an [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource?view=net-5.0) with a `Name` the same as the assembly, `MongoDB.Driver.Core.Extensions.DiagnosticSources`, or use the `DiagnosticsActivityEventSubscriber.ActivitySourceName`. Use this name in any [`ActivityListener`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitylistener?view=net-5.0)-based listeners.
 
 All the available [OpenTelemetry semantic tags](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md) are set.


### PR DESCRIPTION
Hi, I recently ran into an issue where using CaptureCommandText = true with GridFS caused high memory usage. This happens because activity traces end up capturing large binary data from the insert chunk command.

This PR updates the README to clarify this behavior and suggests customizing ShouldStartActivity to avoid the problem.